### PR TITLE
Use prebuilt Docker image for Super-Linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,4 +13,4 @@
           uses: actions/checkout@v2
 
         - name: Lint Code Base
-          uses: github/super-linter@v2.0.0
+          uses: docker://github/super-linter:v2.0.0


### PR DESCRIPTION
Should make actions faster https://github.com/github/super-linter/pull/187/