### PR TITLE
Update example.Caddyfile

### DIFF
--- a/caddy/example.Caddyfile
+++ b/caddy/example.Caddyfile
@@ -5,6 +5,13 @@ feedbin.domain.tld {
   }
 }
 
+api.domain.tld {
+  gzip
+  proxy / http://feedbin-web:3000 {
+    transparent
+  }
+}
+
 camo.feedbin.domain.tld {
   gzip
   proxy / http://camo:8081 {


### PR DESCRIPTION
When I tried to use FeedMe (Android), RSS Tracker (win10) to log in to the self-built Feedbin, I found that the third-party software did not support the login of the self-built feedbin. After using `rake routes` in the feedbin-web container, I found api-related routes. The subdomain matching the main domain name needs to use api.domain.ltd to make api calls, and it must be api.domain.ltd, not api.feedbin.domain.ltd, api.xxx.domain.ltd.