### PR TITLE
Fix typo in `feedbin-refresher/Dockerfile`

### DIFF
--- a/feedbin-refresher/Dockerfile
+++ b/feedbin-refresher/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends libidn11-dev \
     && rm -rf /var/lib/apt/lists/* \
     && git clone https://github.com/feedbin/refresher.git /app \
-    gem install bundler \
+    && gem install bundler \
     && bundle install
 
 CMD ["bundle", "exec", "foreman", "start"]


### PR DESCRIPTION
Missing `&&` before `gem install bundler` failed build of the image