### PR TITLE
add FEEDBIN_URL env to the build process and SMTP env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,10 @@ ENTRY_IMAGE_HOST=minio.feedbin.domain.tld
 EXTRACT_HOST=extract.feedbin.domain.tld
 EXTRACT_USER=username
 EXTRACT_SECRET=secret
+
+# SMTP
+SMTP_ADDRESS=
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_DOMAIN=
+FROM_ADDRESS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.6
 
+ARG FEEDBIN_URL
+
 WORKDIR /app
 
 RUN apt-get update \

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -34,7 +34,10 @@ services:
     restart: always
 
   feedbin-web:
-    build: .
+    build:
+      context: .
+      args:
+        FEEDBIN_URL: ${FEEDBIN_URL}
     environment:
       PORT: 3000
     healthcheck:


### PR DESCRIPTION
The FEEDBIN_URL env variable is needed on the build process when the image is compiling assets like js. There's one js file the `bookmarklet` one to be more precise that need this variable so the bookmarklet can work.

Also the SMTP env variables was added, so you can use the forgot password feature.