### PR TITLE
Bumping postgres version to resolve install issue

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -109,7 +109,7 @@ services:
     restart: always
 
   feedbin-postgres:
-    image: postgres:10
+    image: postgres:13
     env_file:
      - ./.env
     volumes:


### PR DESCRIPTION
As per #40 , the install fails on postgres version 10. 12 or higher is  required for the configuration parameter `default_table_access_method`.