### PR TITLE
Fixes container hostnames in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,15 +21,15 @@ FEEDBIN_HOST=feedbin.domain.tld
 FORCE_SSL=
 
 # Databases
-ELASTICSEARCH_URL=http://elasticsearch:9200
-MEMCACHED_HOSTS=memcached:11211
+ELASTICSEARCH_URL=http://feedbin-elasticsearch:9200
+MEMCACHED_HOSTS=feedbin-memcached:11211
 REDIS_URL=redis://feedbin-redis:6379
 
-POSTGRES=postgres
+POSTGRES=feedbin-postgres
 POSTGRES_USERNAME=feedbin
 POSTGRES_USER=feedbin
 POSTGRES_PASSWORD=
-DATABASE_URL=postgres://feedbin:feedbin@postgres/feedbin_production
+DATABASE_URL=postgres://feedbin:[Your POSTGRESS_PASSWORD Here]@feedbin-postgres/feedbin_production
 
 # S3
 AWS_ACCESS_KEY_ID=


### PR DESCRIPTION
There are a couple errors in the .env.example file. For `ELASTICSEARCH_URL`, `MEMCACHED_HOSTS`, and the postgres url, the hostnames for those containers are incongruent with those in the docker-compose example file