### PR TITLE
Update Feedbin-Image dependencies

### DIFF
--- a/feedbin-image/Dockerfile
+++ b/feedbin-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3
+FROM ruby:2.7
 
 WORKDIR /app
 

--- a/feedbin-image/Dockerfile
+++ b/feedbin-image/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.7
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libopencv-dev \
+    && apt-get install -y --no-install-recommends libvips \
     && rm -rf /var/lib/apt/lists/* \
     && git clone https://github.com/feedbin/image.git /app \
     && gem install bundler \


### PR DESCRIPTION
A recent change in feedbin/image (feedbin/image@829600f) requires an upgrade of Ruby to 2.7 and switching from `libopencv` to  `libvips`. This should fix failing builds and startup of feedbin-image.