### PR TITLE
Make feedbin-extract reusable by fetching secrets from env

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -120,9 +120,6 @@ services:
   feedbin-extract:
     build:
       context: ./feedbin-extract
-      args:
-        EXTRACT_USER: ${EXTRACT_USER}
-        EXTRACT_SECRET: ${EXTRACT_SECRET}
     env_file:
       - ./.env
     restart: always

--- a/feedbin-extract/Dockerfile
+++ b/feedbin-extract/Dockerfile
@@ -1,13 +1,11 @@
 FROM node:12
 
-ARG EXTRACT_USER
-ARG EXTRACT_SECRET
-
 WORKDIR /app
 
 RUN git clone https://github.com/feedbin/extract.git /app \
     && npm install \
-    && mkdir users \
-    && echo ${EXTRACT_SECRET} > users/${EXTRACT_USER}
+    && mkdir users 
 
-CMD ["node", "app/server.js"]
+COPY docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]

--- a/feedbin-extract/docker-entrypoint.sh
+++ b/feedbin-extract/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo ${EXTRACT_SECRET} > users/${EXTRACT_USER}
+node app/server.js


### PR DESCRIPTION
First of all I wanted to thank you for the great docker-compose setup. It really helped me to set up Feedbin on my own! :) 
I wanted to make the setup a bit more reusable, especially to be able to build the images with GitHub Actions, upload them to DockerHub and just fetch them from there. Thats how I noticed that the credentials for feedbin-extract are kind of hard-coded into the image. This PR would change it to store the credentials on startup by fetching them directly from env using a new entrypoint. But I'm happy for suggestions :) 